### PR TITLE
Fix variable placeholder union for prompts

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,7 +156,7 @@ with st.form("editor", clear_on_submit=False):
     # Variables block
     st.markdown("#### Variables")
     # auto-detect
-    detected = sorted(set(extract_placeholders(user_prompt) | set(extract_placeholders(sys_prompt))))
+    detected = sorted(set(extract_placeholders(user_prompt)) | set(extract_placeholders(sys_prompt)))
     st.caption("Detected from prompts: " + (", ".join(detected) if detected else "—"))
     var_rows = st.session_state.get("var_rows", [])
     # sync session var list with detected (add if missing)


### PR DESCRIPTION
## Summary
- avoid TypeError when computing detected variables by unioning sets of placeholders

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b14e973fec83338dbef4b9d9e262fa