### PR TITLE
fix(security): bump Vite to patched 5.4.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
-    "vite": "^5.4.11"
+    "vite": "^5.4.16"
   }
 }


### PR DESCRIPTION
### Motivation
- Address a known Vite security advisory by upgrading the project to a patched `vite` release.

### Description
- Updated `devDependencies.vite` in `package.json` from `^5.4.11` to `^5.4.16` to land the security fix.

### Testing
- Validated `package.json` syntax with `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` (success); `npm install` failed due to registry/proxy `403 Forbidden`; attempts to run `pip-audit -r requirements.txt` and to install `pip-audit` with `python -m pip install pip-audit` were blocked by proxy, so full dependency installation/audit could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccae4d88c88333903cf5ef2c3e5730)